### PR TITLE
Setup pym.js for responsive iframes

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,11 @@
 import React from "react"
+import * as pym from "pym.js"
 import { VizProvider } from "./src/context/vizcontext"
+
+export const onInitialClientRender = () => {
+  const pymChild = new pym.Child({ polling: 500 })
+  pymChild.sendHeight()
+}
 
 export const wrapRootElement = ({ element }) => (
   <VizProvider>{element}</VizProvider>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mapshaper": "^0.5.10",
     "moment": "^2.26.0",
     "prop-types": "^15.7.2",
+    "pym.js": "^1.3.2",
     "react": "^16.13.1",
     "react-bootstrap": "1.0.0",
     "react-bootstrap-table-next": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11373,6 +11373,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pym.js@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/pym.js/-/pym.js-1.3.2.tgz#0ebd083c5a7ef7650214db872b4b29a10743305d"
+  integrity sha512-/fFzHFB4BTsJQP5id0wzUdYsDT4VPkfAxk+uENBE9/aP6YbvhAEpcuJHdjxqisqfXOCrcz7duTK1fbtF2rz8RQ==
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"


### PR DESCRIPTION
Should close #50, adds pym.js on client render for each page.

Embedding is pretty similar to an iframe, but with an HTML snippet like this ([pulled from their docs](http://blog.apps.npr.org/pym.js/#auto)):

```html
<div data-pym-src="https://covid19neighborhoods.southsideweekly.com/map">Loading...</div>
<script type="text/javascript" src="https://pym.nprapps.org/pym-loader.v1.min.js"></script>
```

`data-pym-src` can be replaced with any path on the site. Let me know if there are any changes I should make!